### PR TITLE
Fix compatbility with new comfy frontend

### DIFF
--- a/civitai_checkpoint_loader.py
+++ b/civitai_checkpoint_loader.py
@@ -40,7 +40,7 @@ class CivitAI_Checkpoint_Loader:
                 "ckpt_name": (checkpoints,),
             },
             "optional": {
-                "api_key": ("STRING", {"default": None, "multiline": False}),
+                "api_key": ("STRING", {"default": "", "multiline": False}),
                 "download_chunks": ("INT", {"default": 4, "min": 1, "max": 12, "step": 1}),
                 "download_path": (list(checkpoint_paths.keys()),),
             },

--- a/civitai_lora_loader.py
+++ b/civitai_lora_loader.py
@@ -44,7 +44,7 @@ class CivitAI_LORA_Loader:
 
             },
             "optional": {
-                "api_key": ("STRING", {"default": None, "multiline": False}),
+                "api_key": ("STRING", {"default": "", "multiline": False}),
                 "download_chunks": ("INT", {"default": 4, "min": 1, "max": 12, "step": 1}),
                 "download_path": (list(lora_paths),),
             },


### PR DESCRIPTION
The civitai nodes have `INPUT_TYPES.optional.api_key.default` set to `None`. Since this field is supposed to be string type, the nodes fail type validation (introduced in new ComfyUI frontend) and are not useable. 

I just changed `None` to an empty string to fix it. Empty string is still false implicitly so lines like these won't be affected:

https://github.com/civitai/civitai_comfy_nodes/blob/eaac2c22656fb464ba166c707d67594ff5a1f47d/CivitAI_Model.py#L56 